### PR TITLE
Ajuste para que o script do tower.bash saiba lidar com a env SPECIFIC…

### DIFF
--- a/scripts/tower.bash
+++ b/scripts/tower.bash
@@ -23,7 +23,13 @@ echo $hostval
 echo $userval
 echo $VERSION
 
-# Let's run a tower-cli job
-awx --conf.host https://${hostval} --conf.username ${userval} --conf.password ${passwordval} \
--f human workflow_job_templates launch ${TEMPLATE_ID} \
---extra_vars='{"deploy_version": "'"${VERSION}"'", "deploy_name": "'"${SERVICE_NAME}"'", "commit_message": "'"${COMMIT_MESSAGE}"'"}'
+if [[ -z ${SPECIFIC_SERVICE_TAG} ]]; then
+  echo "SPECIFIC_SERVICE_TAG not set, using NEW template format WITHOUT specific tag"
+  awx --conf.host https://${hostval} --conf.username ${userval} --conf.password ${passwordval} \
+  -f human workflow_job_templates launch ${TEMPLATE_ID} \
+  --extra_vars='{"deploy_version": "'"${VERSION}"'", "deploy_name": "'"${SERVICE_NAME}"'", "commit_message": "'"${COMMIT_MESSAGE}"'"}'
+else
+  awx --conf.host https://${hostval} --conf.username ${userval} --conf.password ${passwordval} \
+  -f human workflow_job_templates launch ${TEMPLATE_ID} \
+  --extra_vars='{"deploy_version": "'"${VERSION}"'", "deploy_name": "'"${SERVICE_NAME}"'", "commit_message": "'"${COMMIT_MESSAGE}"'", "specific_service_tag": "'"${SPECIFIC_SERVICE_TAG}"'"}'
+fi

--- a/scripts/tower.bash
+++ b/scripts/tower.bash
@@ -24,7 +24,6 @@ echo $userval
 echo $VERSION
 
 if [[ -z ${SPECIFIC_SERVICE_TAG} ]]; then
-  echo "SPECIFIC_SERVICE_TAG not set, using NEW template format WITHOUT specific tag"
   awx --conf.host https://${hostval} --conf.username ${userval} --conf.password ${passwordval} \
   -f human workflow_job_templates launch ${TEMPLATE_ID} \
   --extra_vars='{"deploy_version": "'"${VERSION}"'", "deploy_name": "'"${SERVICE_NAME}"'", "commit_message": "'"${COMMIT_MESSAGE}"'"}'


### PR DESCRIPTION
Ajuste para o tower.bash ser capaz de lidar com a nova variavel de ambiente SPECIFIC_SERVICE_TAG, quer será usada nos casos dos deployments em que o grupo tem mais de uma variavel de TAG no .env .
O compotamento antigo é mantido para os casos em que a SPECIFIC_SERVICE_TAG não é passada, portanto não é pra precisar de nenhuma mudança por parte dos times nos pipelines que ja existam.