### PR TITLE
Add script for uploading api documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2021-03-10
+
+### Added
+
+- `update-api-doc` script to push swagger.json documentation
+to a GCS bucket
+
 ## [2.2.1] - 2020-10-22
 
 ### Fixed

--- a/scripts/update-api-doc
+++ b/scripts/update-api-doc
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function require_variable {
+	for var in $@; do
+		echo "Checking if varible is set: ${var}=$(eval echo \$${var})"
+		if [ -z "$(eval echo \$${var})" ]; then
+			echo "missing or empty '${var}' variable"
+			exit 1
+		fi
+	done
+}
+
+require_variable \
+  KEYFILE \
+  PROJECT \
+  FILE \
+  GROUP \
+  API_NAME \
+  VERSION
+
+BUCKET=${BUCKET:-"arquivei-internal-apis-docs"}
+
+
+echo "${KEYFILE}" | base64 -d | gcloud auth activate-service-account --project "${PROJECT}" --quiet --key-file=-
+
+sed -i -e "s/{{version}}/${VERSION}/g" "${FILE}"
+gsutil cp "${FILE}" "gs://${BUCKET}/${GROUP}/${API_NAME}.json"


### PR DESCRIPTION
Example usage in a bitbucket pipeline:

```yaml
    - step: &release-api-doc
        name: "Release api documentation"
        image: arquivei/pipeline:v2
        script:
          - KEYFILE=${BASE64_KEYFILE}
          - PROJECT=${BUCKET_PROJECT}
          - FILE=path/to/swagger.json
          - GROUP=group
          - API_NAME=api-name
          - VERSION=`git describe --tags --always`
          - . update-api-doc
```