### PR TITLE
Added support for the Packer build call on AWX

### DIFF
--- a/scripts/tower.bash
+++ b/scripts/tower.bash
@@ -82,6 +82,10 @@ case $TOWER_OPTION in
     dataflow_deploy
     ;;
 
+  packer_build_image)
+    packer_build
+    ;;
+
   *)
     echo "Option not valid, exiting"
     exit 1

--- a/scripts/tower.bash
+++ b/scripts/tower.bash
@@ -55,9 +55,25 @@ function dataflow_deploy(){
     --extra_vars='{"gcp_project": "'"${GCP_PROJECT}"'", "project_name": "'"${PROJECT_NAME}"'",  "project_simple_version": "'"${PROJECT_SIMPLE_VERSION}"'",  "project_version": "'"${PROJECT_VERSION}"'",  "running_env": "'"${RUNNING_ENV}"'",  "srcproject": "'"${SRCPROJECT}"'"}'
 }
 
+function packer_build() {
+  echo "current configuration settings:"
+  echo $hostval
+  echo $userval
+  echo $VERSION
+  echo
+  echo "SRCPROJECT: $SRCPROJECT"
+  echo "GIT_BRANCH: $GIT_BRANCH"
+  echo "PACKER_FOLDER: $PACKER_FOLDER"
+  echo "PACKER_VAR_FILE: $PACKER_VAR_FILE"
+
+  awx --conf.host https://${hostval} --conf.username ${userval} --conf.password ${passwordval} \
+    -f human job_templates launch ${TEMPLATE_ID} \
+    --extra_vars='{"srcproject": "'"${SRCPROJECT}"'", "git_branch": "'"${GIT_BRANCH}"'",  "packer_folder": "'"${PACKER_FOLDER}"'",  "packer_var_file": "'"${PACKER_VAR_FILE}"'"}'
+}
+
 
 case $TOWER_OPTION in
-  
+
   kubernetes_deploy)
     k8s_deploy
     ;;


### PR DESCRIPTION
Adding a function to call AWX Packer Build Job Template (not workflow)
to build a new image using Packer.

Required variables are:

- GIT_BRANCH: which git branch to use when cloning - can be a git tag
- SRCPROJECT: slug of the repository
- PACKER_FOLDER: relative path for the folder containing Packer config
- PACKER_VAR_FILE: relative path from PACKER_FOLDER for the variable
  file

Signed-off-by: Ricardo Verhaeg <ricardo@arquivei.com.br>